### PR TITLE
Build under go 1.14

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -1,7 +1,7 @@
 rule compile
-  command = go tool 6g -o $out $in
+  command = go tool compile -o $out $in
 rule link
-  command = go tool 6l -o $out $in
+  command = go tool link -o $out $in
 
 build mt.6: compile linux_mangle_test.go linux_mangle.go parse.go
 build mt: link mt.6


### PR DESCRIPTION
The build script won't work in the latest version of go, so I update it. Hope it will help for other new comers.

> [**Renaming**](https://golang.org/doc/go1.5#rename)
>
> The suites of programs that were the compilers (6g, 8g, etc.), the assemblers (6a, 8a, etc.), and the linkers (6l, 8l, etc.) have each been consolidated into a single tool that is configured by the environment variables GOOS and GOARCH. The old names are gone; the new tools are available through the go tool mechanism as go tool compile, go tool asm, and go tool link. Also, the file suffixes .6, .8, etc. for the intermediate object files are also gone; now they are just plain .o files. 
